### PR TITLE
added a friendly ID for peers in the room

### DIFF
--- a/src/html/room.html
+++ b/src/html/room.html
@@ -35,7 +35,16 @@
               <input class="file-path validate" type="text" placeholder="Upload a video to stream" disabled="true">
             </div>
       <div class="col s6">
-        <div class="row left col s3 push-s9">
+        <div class="col s4" onclick="enableInput()">
+          <!-- <h5 id="peer-alias">peerID</h5> -->
+          <input class="validate" type="text" id="peer-alias" placeholder="Type your alias in here" >
+        </div>
+        <div class="col s4">
+          <div class="btn disabled z-depth-3 red darken-4 col s12" onclick="setAlias()" id="alias-btn">
+            <span>Set Alias!</span>
+          </div>
+        </div>
+        <div class="row left col s3 push-s1">
             <a id="stream" onclick="streamVideo()" class="btn disabled brown darken-2"><span class="black-text">Stream!</span></a>
         </div>
       </div>

--- a/src/js/room.js
+++ b/src/js/room.js
@@ -58,7 +58,11 @@ if (window.location.href.length - peerID.length == baseURL.length){
 
 window.onbeforeunload = function exitPeer(){
 	peerConnections.map(function(currentPeer){
-		peerChannel[currentPeer].send(JSON.stringify({"peerID": peerID, "exitPeer": true, "peerIDServer": peerIDServer}));
+		if(alias == null){
+			peerChannel[currentPeer].send(JSON.stringify({"peerID": peerID, "exitPeer": true, "peerIDServer": peerIDServer}));
+		}else{
+			peerChannel[currentPeer].send(JSON.stringify({"peerID": alias, "exitPeer": true, "peerIDServer": peerIDServer}));
+		}
 	});
 }
 


### PR DESCRIPTION
This is in reference to #8 
I have added an optional friendly ID for the peers in room mostly used for play/pause messages and goodbye messages
I have tried to take in account all the test cases about the visibility of `set alias` btn and the input field and moreover made it independent of the peer joining time. I have tried to keep it clean
kindly have a look :smile: 